### PR TITLE
Support animations without end values in each keyframe

### DIFF
--- a/LottieSharp/Animation/Keyframe/PathKeyframe.cs
+++ b/LottieSharp/Animation/Keyframe/PathKeyframe.cs
@@ -5,19 +5,27 @@ namespace LottieSharp.Animation.Keyframe
 {
     public class PathKeyframe : Keyframe<Vector2?>
     {
+        private readonly Keyframe<Vector2?> _pointKeyFrame;
+
         public PathKeyframe(LottieComposition composition, Keyframe<Vector2?> keyframe)
             : base(composition, keyframe.StartValue, keyframe.EndValue, keyframe.Interpolator, keyframe.StartFrame, keyframe.EndFrame)
+        {
+            _pointKeyFrame = keyframe;
+            CreatePath();
+        }
+
+        internal void CreatePath()
         {
             var equals = EndValue != null && StartValue != null && StartValue.Equals(EndValue.Value);
             if (EndValue != null && !equals)
             {
-                Path = Utils.Utils.CreatePath(StartValue.Value, EndValue.Value, keyframe.PathCp1, keyframe.PathCp2);
+                Path = Utils.Utils.CreatePath(StartValue.Value, EndValue.Value, _pointKeyFrame.PathCp1, _pointKeyFrame.PathCp2);
             }
         }
 
         /// <summary>
         /// This will be null if the startValue and endValue are the same.
         /// </summary>
-        internal Path Path { get; }
+        internal Path Path { get; private set; }
     }
 }

--- a/LottieSharp/Parser/AnimatableTransformParser.cs
+++ b/LottieSharp/Parser/AnimatableTransformParser.cs
@@ -54,6 +54,14 @@ namespace LottieSharp.Parser
                         break;
                     case "r":
                         rotation = AnimatableValueParser.ParseFloat(reader, composition, false);
+                        if (rotation.Keyframes.Count == 0)
+                        {
+                            rotation.Keyframes.Add(new Keyframe<float?>(composition, 0f, 0f, null, 0f, composition.EndFrame));
+                        }
+                        else if (rotation.Keyframes[0].StartValue == null)
+                        {
+                            rotation.Keyframes[0] = new Keyframe<float?>(composition, 0f, 0f, null, 0f, composition.EndFrame);
+                        }
                         break;
                     case "o":
                         opacity = AnimatableValueParser.ParseInteger(reader, composition);

--- a/LottieSharp/Parser/KeyframesParser.cs
+++ b/LottieSharp/Parser/KeyframesParser.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using LottieSharp.Animation.Keyframe;
 using LottieSharp.Value;
 using Newtonsoft.Json;
 
@@ -69,10 +70,18 @@ namespace LottieSharp.Parser
             for (int i = 0; i < size - 1; i++)
             {
                 // In the json, the keyframes only contain their starting frame. 
-                keyframes[i].EndFrame = keyframes[i + 1].StartFrame;
-            }
+                // keyframes[i].EndFrame = keyframes[i + 1].StartFrame;
+                var keyframe = keyframes[i];
+                Keyframe<TV> nextKeyframe = keyframes[i + 1];
+                keyframe.EndFrame = nextKeyframe.StartFrame;
+                if (keyframe.EndValue == null && nextKeyframe.StartValue != null)
+                {
+                    keyframe.EndValue = nextKeyframe.StartValue;
+                    (keyframe as PathKeyframe)?.CreatePath();
+                }
+    }
             var lastKeyframe = keyframes[size - 1];
-            if (lastKeyframe.StartValue == null)
+            if ((lastKeyframe.StartValue == null || lastKeyframe.EndValue == null) && keyframes.Count > 1)
             {
                 // The only purpose the last keyframe has is to provide the end frame of the previous 
                 // keyframe. 

--- a/LottieSharp/Parser/KeyframesParser.cs
+++ b/LottieSharp/Parser/KeyframesParser.cs
@@ -70,7 +70,6 @@ namespace LottieSharp.Parser
             for (int i = 0; i < size - 1; i++)
             {
                 // In the json, the keyframes only contain their starting frame. 
-                // keyframes[i].EndFrame = keyframes[i + 1].StartFrame;
                 var keyframe = keyframes[i];
                 Keyframe<TV> nextKeyframe = keyframes[i + 1];
                 keyframe.EndFrame = nextKeyframe.StartFrame;

--- a/LottieSharp/Value/Keyframe.cs
+++ b/LottieSharp/Value/Keyframe.cs
@@ -6,7 +6,7 @@ namespace LottieSharp.Value
     {
         private readonly LottieComposition _composition;
         public T StartValue { get; }
-        public T EndValue { get; }
+        public T EndValue { get; internal set; }
         public IInterpolator Interpolator { get; }
         public float? StartFrame { get; }
         public float? EndFrame { get; internal set; }


### PR DESCRIPTION
Newer versions of Bodymovin (5.5+) produce animations without end values in each keyframe (apparently to reduce the size of the JSON).  This PR provides support for this.

It is ported almost directly from the lottie-android PR:
https://github.com/airbnb/lottie-android/pull/1104